### PR TITLE
[PATCH] Fix references from `cmdtab` to `cmdbox`

### DIFF
--- a/pomo/main.go
+++ b/pomo/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/rwxrob/cmdtab"
-	_ "github.com/rwxrob/cmdtab-pomo"
+	_ "github.com/rwxrob/cmdbox-pomo"
 )
 
 func main() {


### PR DESCRIPTION
It must've been left out from the refactor in
377cae1b63c5317546c9f99a2deb7e0b2a75b882 and it was causing the build to
fail.