### PR TITLE
pomo file prints config file absolute path

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	x := cmdtab.New("pomo", "start", "stop", "duration", "emoji", "help", "version")
+	x := cmdtab.New("pomo", "start", "stop", "duration", "emoji", "help", "version", "file")
 	x.Summary = `sets or prints a countdown timer (with tomato)`
 	x.Usage = `[start|stop|duration|emoji|emoji.blink]`
 	x.Version = `v1.0.0`
@@ -77,6 +77,10 @@ func init() {
 				config.SetSave("pomo.emoji", args[1])
 			case "emoji.blink":
 				config.SetSave("pomo.emoji.blink", args[1])
+			case "file":
+				configFile := config.Path()
+				fmt.Printf("Configuration file: %s\n", configFile)
+				return nil
 			default:
 				return x.UsageError()
 			}


### PR DESCRIPTION
`pomo file` prints the absolute path to the configuration file.

Should close #21 