### PR TITLE
implemented pause

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	x := cmdbox.New("pomo", "start", "stop", "duration", "emoji", "help", "version", "file")
+	x := cmdbox.New("pomo", "start", "stop", "pause", "resume", "duration", "emoji", "help", "version", "file")
 	x.Summary = `sets or prints a countdown timer (with tomato)`
 	x.Usage = `[start|stop|duration|emoji|emoji.blink]`
 	x.Version = `v1.0.0`
@@ -58,6 +58,7 @@ func init() {
 			switch args[0] {
 			case "stop":
 				config.SetSave("pomo.up", "")
+				config.SetSave("pomo.status", "")
 			case "duration":
 				config.SetSave("pomo.duration", args[1])
 				fallthrough
@@ -67,12 +68,32 @@ func init() {
 					s = "25m"
 					config.Set("pomo.duration", s)
 				}
-				dur, err := time.ParseDuration(s)
+				if err := run(s, config); err != nil {
+					return err
+				}
+			case "pause":
+				up := config.Get("pomo.up")
+				if up == "" {
+					return nil
+				}
+				endt, err := time.Parse(time.RFC3339, up)
 				if err != nil {
 					return err
 				}
-				up := time.Now().Add(dur).Format(time.RFC3339)
-				config.SetSave("pomo.up", up)
+				config.SetSave("pomo.duration", endt.Sub(time.Now()).Round(time.Second).String())
+				config.SetSave("pomo.status", "paused")
+			case "resume":
+				status := config.Get("pomo.status")
+				if status == "" {
+					return nil
+				}
+				dur := config.Get("pomo.duration")
+				if dur == "" {
+					return nil
+				}
+				if err := run(dur, config); err != nil {
+					return err
+				}
 			case "emoji":
 				config.SetSave("pomo.emoji", args[1])
 			case "emoji.blink":
@@ -98,12 +119,39 @@ func init() {
 			emoji = "🍅"
 		}
 		blinkEmoji := config.Get("pomo.emoji.blink")
-		timeLeft := endt.Sub(time.Now()).Round(time.Second)
+		var timeLeft time.Duration
+		status := config.Get("pomo.status")
+		if status == "paused" {
+			timeLeft, err = time.ParseDuration(config.Get("pomo.duration"))
+			if err != nil {
+				return err
+			}
+		} else {
+			timeLeft = endt.Sub(time.Now()).Round(time.Second)
+		}
 		if timeLeft < time.Second*30 && timeLeft%(time.Second*2) == 0 {
-			fmt.Printf("%v %v\n", blinkEmoji, timeLeft)
+			fmt.Printf("%v %v%s\n", blinkEmoji, timeLeft, displayStatus(status))
 			return nil
 		}
-		fmt.Printf("%v %v\n", emoji, timeLeft)
+		fmt.Printf("%v %v%s\n", emoji, timeLeft, displayStatus(status))
 		return nil
 	}
+}
+
+func run(duration string, config *conf.Config) error {
+	dur, err := time.ParseDuration(duration)
+	if err != nil {
+		return err
+	}
+	up := time.Now().Add(dur).Format(time.RFC3339)
+	config.SetSave("pomo.up", up)
+	config.SetSave("pomo.status", "")
+	return nil
+}
+
+func displayStatus(s string) string {
+	if s == "paused" {
+		return " (PAUSED)"
+	}
+	return ""
 }


### PR DESCRIPTION
Added pause functionallity. Run `pomo pause` to pause the pomodoro and `pomo start` or `pomo resume` to start the pomodoro timer again.
` (PAUSED)` is added next to the pomodoro timer while paused.

`pomo.pause` override the initial value in `config.json` `pomo.duration`. A `pomo duration <duration>` is required to reset `pomo.duration` to e.g. `25m`

Hopefully close #24 